### PR TITLE
Changes for Beat Saber 1.36.2

### DIFF
--- a/AudioLink/AudioLink.csproj
+++ b/AudioLink/AudioLink.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Reference Include="0Harmony" HintPath="$(BeatSaberDir)\Libs\0Harmony.dll" />
     <Reference Include="Colors" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll" />
+    <Reference Include="DataModels" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll" />
     <Reference Include="IPA.Loader" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll" />
     <Reference Include="Main" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll" Publicize="true" />
     <Reference Include="SiraUtil" HintPath="$(BeatSaberDir)\Plugins\SiraUtil.dll" />

--- a/AudioLink/Plugin.cs
+++ b/AudioLink/Plugin.cs
@@ -48,7 +48,7 @@ namespace AudioLink
             }
             else
             {
-                SongCore.Collections.DeregisterizeCapability(CAPABILITY);
+                SongCore.Collections.DeregisterCapability(CAPABILITY);
             }
         }
     }


### PR DESCRIPTION
- `PlayerDataModel` was moved to `DataModels.dll` so add reference
- SongCore.Collections.DeregisterizeCapability was renamed